### PR TITLE
Propagate document tags from backend to context

### DIFF
--- a/client/src/context/DisplayContext.tsx
+++ b/client/src/context/DisplayContext.tsx
@@ -685,6 +685,12 @@ const deleteNotice = async (id: string): Promise<boolean> => {
                 url: fullUrl,
                 type: docType as any, // Usar o tipo do servidor diretamente
                 category: docType === 'escala' ? category : undefined,
+                tags: Array.isArray(serverDoc.tags)
+                  ? [...serverDoc.tags]
+                  : serverDoc.tags
+                    ? [String(serverDoc.tags)]
+                    : [],
+                unit: serverDoc.unit as PDFDocument['unit'] | undefined,
                 active: true
               };
               

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -996,12 +996,20 @@ if (selectedDocType === "cardapio" && !docUnit) {
         category: selectedDocType === "escala" ? docCategory : undefined
       });
       
+      const uploadTags = Array.isArray(uploadResult.data?.tags)
+        ? uploadResult.data.tags
+        : [];
+
+      const uploadUnit = (uploadResult.data?.unit as PDFDocument['unit'] | undefined)
+        ?? (selectedDocType === "cardapio" ? docUnit : undefined);
+
       addDocument({
         title: docTitle,
         url: fullUrl,
         type: selectedDocType,
         category: selectedDocType === "escala" ? docCategory : undefined,
-        unit: selectedDocType === "cardapio" ? docUnit : undefined, 
+        unit: uploadUnit,
+        tags: uploadTags,
         active: true
       });
       
@@ -1019,6 +1027,8 @@ if (selectedDocType === "cardapio" && !docUnit) {
         url: fullUrl,
         type: selectedDocType,
         category: selectedDocType === "escala" ? docCategory : undefined,
+        unit: selectedDocType === "cardapio" ? docUnit : undefined,
+        tags: [],
         active: true
       });
       


### PR DESCRIPTION
## Summary
- copy backend-provided tag and unit metadata when syncing documents from the server
- forward classification tags and unit data during uploads and direct URL additions in the admin UI

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dedda376e48321928f78dcdc1ecebf